### PR TITLE
Fix not to block tornado while requesting to sidestickies

### DIFF
--- a/devRequirements.txt
+++ b/devRequirements.txt
@@ -1,3 +1,4 @@
 mock
 pytest
+pytest-asyncio
 pep8

--- a/devRequirements.txt
+++ b/devRequirements.txt
@@ -1,4 +1,4 @@
-mock
-pytest
+mock >= 4
+pytest >= 5.4
 pytest-asyncio
 pep8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 notebook>=5.0.0
-requests

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup_args = dict(name='lc-nbtags',
                   package_data={'nbtags': ['nbextension/*']},
                   include_package_data=True,
                   platforms=['Jupyter Notebook 5.x'],
-                  install_requires=['notebook>=5.0.0', 'requests'])
+                  install_requires=['notebook>=5.0.0'])
 
 if __name__ == '__main__':
     setup(**setup_args)


### PR DESCRIPTION
Fixed #9 

sidestickiesへのリクエストで時間がかかるケースで、他のtornadoのハンドラがブロックされてしまう問題を修正しました。
Scrapboxへのリクエストをrequestsで同期的に行っていたので、async/awaitとtornadoのAsyncHTTPClientを使って非同期に行うようにしました。