### PR TITLE
Improve scan tree performance

### DIFF
--- a/nbtags/nbextension/tree.js
+++ b/nbtags/nbextension/tree.js
@@ -19,6 +19,10 @@ define([
     var last_url = null;
     var visible = false;
 
+    const scan_tree_interval_ms = 500;
+    let scan_tree_timer_id = null;
+    let scan_tree_last_time = Date.now();
+
     function extend_file(item) {
         var a = item.find('a');
         var path = a.attr('href');
@@ -108,6 +112,20 @@ define([
     }
 
     function scan_tree() {
+        if (scan_tree_timer_id) return;
+        const elapsed = Date.now() - scan_tree_last_time;
+        if (elapsed > scan_tree_interval_ms) {
+            _scan_tree();
+        } else {
+            scan_tree_timer_id = setTimeout(() => {
+                scan_tree_timer_id = null;
+                _scan_tree();
+            }, scan_tree_interval_ms - elapsed);
+        }
+    }
+
+    function _scan_tree() {
+        scan_tree_last_time = Date.now();
         var actives = [];
         $('#notebook_list .list_item').each(function(i, e) {
             var path = extend_file($(e));

--- a/nbtags/nbextension/tree.js
+++ b/nbtags/nbextension/tree.js
@@ -170,7 +170,10 @@ define([
 
         scan_tree();
         const observer = new MutationObserver((mutations) => {
-            scan_tree();
+            const filtered = mutations.filter(mutation => $(mutation.target).closest('.nbtags-base').length === 0);
+            if (filtered.length > 0) {
+                scan_tree();
+            }
         });
         observer.observe($("#notebook_list").get(0), {
             attributes: true,

--- a/nbtags/nbextension/tree.js
+++ b/nbtags/nbextension/tree.js
@@ -135,8 +135,13 @@ define([
         load_extension();
 
         scan_tree();
-        $("#notebook_list").bind("DOMSubtreeModified", function() {
+        const observer = new MutationObserver((mutations) => {
             scan_tree();
+        });
+        observer.observe($("#notebook_list").get(0), {
+            attributes: true,
+            characterData: true,
+            subtree: true
         });
         var toggle_button = $('<button></button>')
                                 .addClass('btn btn-default btn-xs')

--- a/nbtags/nbextension/tree.js
+++ b/nbtags/nbextension/tree.js
@@ -38,6 +38,22 @@ define([
             return t.path == contentPath;
         });
         if (old.length > 0) {
+            const t = old[0];
+            const itemElement = item.find('.col-md-12');
+            if (itemElement.find('.nbtags-base').length === 0) {
+                console.log(log_prefix, 'Reattachment', contentPath, itemName);
+                t.createElement(function(child) {
+                    itemElement.append(child);
+                    if (t.cachedJSON) {
+                        t.updateContent(t.cachedJSON);
+                    } else {
+                        tagging.check_content(t);
+                    }
+                });
+                if (visible) {
+                    t.show();
+                }
+            }
             return contentPath;
         }
         var cached = cached_tags.filter(function(t) {


### PR DESCRIPTION
tree画面のnbtagsを更新する処理のパフォーマンスを改善しました。

- DOMSubtreeModifiedではなくMutationObserverを使い、DOMの更新イベントをまとめて取得するようにしました。
    - ※DOMSubtreeModifiedはdeprecated (https://developer.mozilla.org/en-US/docs/Archive/Events/DOMSubtreeModified)
    - cb9d823 は、scan_treeが実行されるタイミングが変わったことによる修正です。
- nbtagsの更新によってscan_treeが実行されないようにしました。
- scan_treeが連続して何度も実行されないよう、間引き処理を追加しました。

