### PR TITLE
FIx a bug for request Scrapbox API

### DIFF
--- a/nbtags/scrapbox.py
+++ b/nbtags/scrapbox.py
@@ -1,4 +1,5 @@
 import json
+import urllib
 from urllib.parse import urlencode, quote
 from tornado.httpclient import HTTPRequest, AsyncHTTPClient
 from traitlets import Unicode
@@ -22,7 +23,7 @@ class ScrapboxAPI(LoggingConfigurable):
 
     async def get(self, meme):
         url = self._scrapbox_endpoint('pages/{}/{}'.format(self.project_id,
-                                                               meme))
+                                                           urllib.parse.quote(meme, safe="")))
         http_client = AsyncHTTPClient()
         if self.cookie_connect_sid:
             req = HTTPRequest(url=url, headers={'Cookie': f'connect.sid={self.cookie_connect_sid}'})


### PR DESCRIPTION
#10 により発生した不具合の修正です。

requests ではURLを内部でエンコードしてくれていたのですが、tornado.httpclient ではパラメーターとして渡したURLをそのまま使うようで、付箋のタイトルに `a a` のようにスペースを含む場合にHTTP Requestが失敗するという問題がありました。
urllib.parse.quoteを使って最後のパス部分をエンコードするよう修正しました。