### PR TITLE
Upgrade actions/upload-artifact and download-artifact of the GitHub workflow  because v2 is deprecated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         pip uninstall -y "sidestickies" jupyterlab
         rm -rf myextension
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: myextension-sdist
         path: myextension.tar.gz
@@ -52,7 +52,7 @@ jobs:
       with:
         python-version: '3.9'
         architecture: 'x64'
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
       with:
         name: myextension-sdist
     - name: Install and Test

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -57,7 +57,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Upload Distributions
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: sidestickies-releaser-dist-${{ github.run_number }}
           path: .jupyter_releaser_checkout/dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,12 +71,12 @@ jobs:
         npm pack
         mv sidestickies-*.tgz myextension-nodejs.tgz
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: myextension-sdist
         path: myextension.tar.gz
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: myextension-nodejs
         path: myextension-nodejs.tgz
@@ -88,10 +88,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
       with:
         name: myextension-sdist
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
       with:
         name: myextension-nodejs
     - name: release


### PR DESCRIPTION
Fixed the workflow because the release via GitHub Actions was failing.